### PR TITLE
Decouple blend shape weights into SkinnedMeshRendererBlendShapeUpdate

### DIFF
--- a/proto/plume/sample/unity/skinned_mesh_renderer.proto
+++ b/proto/plume/sample/unity/skinned_mesh_renderer.proto
@@ -15,22 +15,21 @@ message SkinnedMeshRendererDestroy {
 
 message SkinnedMeshRendererUpdate {
     ComponentIdentifier component = 1;
-    
+
     optional AssetIdentifier mesh = 2;
     optional ComponentIdentifier root_bone = 3;
     optional Bones bones = 4;
-    optional BlendShapeWeights blend_shape_weights = 5;
-    
+    reserved 5; // was blend_shape_weights; decoupled into SkinnedMeshRendererBlendShapeUpdate
+
     message Bones {
         repeated ComponentIdentifier ids = 1;
     }
+}
 
-    message BlendShapeWeights {
-        repeated BlendShapeWeight weights = 1;
-
-        message BlendShapeWeight {
-            int32 index = 1;
-            float weight = 2;
-        }
-    }
+// Blend shape weights recorded on their own high-frequency stream (decoupled from SkinnedMeshRendererUpdate)
+// so a face rig animating every frame can be captured with zero GC allocation. Weights are packed floats in
+// shape index order (0..blendShapeCount-1); the index is implicit.
+message SkinnedMeshRendererBlendShapeUpdate {
+    ComponentIdentifier component = 1;
+    repeated float weights = 2 [packed = true];
 }


### PR DESCRIPTION
Moves blend shape weights out of `SkinnedMeshRendererUpdate` into a dedicated `SkinnedMeshRendererBlendShapeUpdate` message so they can be recorded on an independent, allocation-free per-frame stream (animator-driven weights bypass the `SetBlendShapeWeight` hook and must be polled).

Source-of-truth for the recorder's blend shape polling module.

**Breaking:** `SkinnedMeshRendererUpdate` field 5 (`blend_shape_weights`) is now `reserved`; old `.plm` records lose that field on replay. Consumers regenerate and read weights from the new message.