### PR TITLE
Add HDRP sample messages

### DIFF
--- a/proto/plume/sample/unity/hdrp/additional_camera_data.proto
+++ b/proto/plume/sample/unity/hdrp/additional_camera_data.proto
@@ -1,0 +1,62 @@
+syntax = "proto3";
+
+package plume.sample.unity.hdrp;
+option csharp_namespace = "PLUME.Sample.Unity.HDRP";
+
+import "plume/sample/unity/identifiers.proto";
+import "plume/sample/common/color.proto";
+
+message HDAdditionalCameraDataCreate {
+    ComponentIdentifier component = 1;
+}
+
+message HDAdditionalCameraDataDestroy {
+    ComponentIdentifier component = 1;
+}
+
+// Mirrors UnityEngine.Rendering.HighDefinition.HDAdditionalCameraData.
+message HDAdditionalCameraDataUpdate {
+    ComponentIdentifier component = 1;
+    optional HDClearColorMode clear_color_mode = 2;
+    optional common.Color background_color_hdr = 3;
+    optional bool clear_depth = 4;
+    optional int32 volume_layer_mask = 5;
+    optional ComponentIdentifier volume_anchor_override = 6;
+    optional HDCameraAntialiasingMode antialiasing = 7;
+    optional HDSMAAQualityLevel smaa_quality = 8;
+    optional HDTAAQualityLevel taa_quality = 9;
+    optional bool dithering = 10;
+    optional bool stop_nans = 11;
+    optional bool custom_rendering_settings = 12;
+    optional bool xr_rendering = 13;
+    // Physical camera / exposure-relevant
+    optional float focus_distance = 14;
+    optional int32 iso = 15;
+    optional float shutter_speed = 16;
+    optional float aperture = 17;
+}
+
+enum HDClearColorMode {
+    HD_CLEAR_COLOR_MODE_SKY = 0;
+    HD_CLEAR_COLOR_MODE_COLOR = 1;
+    HD_CLEAR_COLOR_MODE_NONE = 2;
+}
+
+enum HDCameraAntialiasingMode {
+    HD_CAMERA_ANTIALIASING_MODE_NONE = 0;
+    HD_CAMERA_ANTIALIASING_MODE_FAST_APPROXIMATE = 1;
+    HD_CAMERA_ANTIALIASING_MODE_TEMPORAL = 2;
+    HD_CAMERA_ANTIALIASING_MODE_SUBPIXEL_MORPHOLOGICAL = 3;
+}
+
+enum HDSMAAQualityLevel {
+    HDSMAA_QUALITY_LEVEL_LOW = 0;
+    HDSMAA_QUALITY_LEVEL_MEDIUM = 1;
+    HDSMAA_QUALITY_LEVEL_HIGH = 2;
+}
+
+enum HDTAAQualityLevel {
+    HDTAA_QUALITY_LEVEL_LOW = 0;
+    HDTAA_QUALITY_LEVEL_MEDIUM = 1;
+    HDTAA_QUALITY_LEVEL_HIGH = 2;
+}

--- a/proto/plume/sample/unity/hdrp/additional_light_data.proto
+++ b/proto/plume/sample/unity/hdrp/additional_light_data.proto
@@ -1,0 +1,51 @@
+syntax = "proto3";
+
+package plume.sample.unity.hdrp;
+option csharp_namespace = "PLUME.Sample.Unity.HDRP";
+
+import "plume/sample/unity/identifiers.proto";
+import "plume/sample/common/color.proto";
+
+message HDAdditionalLightDataCreate {
+    ComponentIdentifier component = 1;
+}
+
+message HDAdditionalLightDataDestroy {
+    ComponentIdentifier component = 1;
+}
+
+// Mirrors UnityEngine.Rendering.HighDefinition.HDAdditionalLightData.
+// HDRP reads the authoritative directional-light intensity (lux) and the
+// sky/sun interaction from here, NOT from the built-in Light component.
+message HDAdditionalLightDataUpdate {
+    ComponentIdentifier component = 1;
+    optional float intensity = 2;
+    optional HDLightUnit light_unit = 3;
+    optional common.Color color = 4;
+    optional float color_temperature = 5;
+    optional bool use_color_temperature = 6;
+    optional bool interacts_with_sky = 7;     // drives Physically Based Sky
+    optional bool affect_diffuse = 8;
+    optional bool affect_specular = 9;
+    optional bool affects_volumetric = 10;
+    optional float light_dimmer = 11;
+    optional float volumetric_dimmer = 12;
+    optional float shadow_dimmer = 13;
+    optional float volumetric_shadow_dimmer = 14;
+    optional float volumetric_fade_distance = 15;
+    optional float range = 16;
+    optional float shape_radius = 17;
+    optional float shape_width = 18;
+    optional float shape_height = 19;
+    optional bool apply_range_attenuation = 20;
+    optional common.Color surface_tint = 21;
+    optional common.Color shadow_tint = 22;
+}
+
+enum HDLightUnit {
+    HD_LIGHT_UNIT_LUMEN = 0;
+    HD_LIGHT_UNIT_CANDELA = 1;
+    HD_LIGHT_UNIT_LUX = 2;
+    HD_LIGHT_UNIT_NITS = 3;
+    HD_LIGHT_UNIT_EV100 = 4;
+}

--- a/proto/plume/sample/unity/hdrp/additional_light_data.proto
+++ b/proto/plume/sample/unity/hdrp/additional_light_data.proto
@@ -15,37 +15,23 @@ message HDAdditionalLightDataDestroy {
 }
 
 // Mirrors UnityEngine.Rendering.HighDefinition.HDAdditionalLightData.
-// HDRP reads the authoritative directional-light intensity (lux) and the
-// sky/sun interaction from here, NOT from the built-in Light component.
+// Only HDRP-specific light data lives here. Intensity, light unit, color, color
+// temperature and range are on the core UnityEngine.Light component (recorded by
+// the core Light module) — HDRP reads them from there (legacyLight.intensity /
+// legacyLight.lightUnit).
 message HDAdditionalLightDataUpdate {
     ComponentIdentifier component = 1;
-    optional float intensity = 2;
-    optional HDLightUnit light_unit = 3;
-    optional common.Color color = 4;
-    optional float color_temperature = 5;
-    optional bool use_color_temperature = 6;
-    optional bool interacts_with_sky = 7;     // drives Physically Based Sky
-    optional bool affect_diffuse = 8;
-    optional bool affect_specular = 9;
-    optional bool affects_volumetric = 10;
-    optional float light_dimmer = 11;
-    optional float volumetric_dimmer = 12;
-    optional float shadow_dimmer = 13;
-    optional float volumetric_shadow_dimmer = 14;
-    optional float volumetric_fade_distance = 15;
-    optional float range = 16;
-    optional float shape_radius = 17;
-    optional float shape_width = 18;
-    optional float shape_height = 19;
-    optional bool apply_range_attenuation = 20;
-    optional common.Color surface_tint = 21;
-    optional common.Color shadow_tint = 22;
-}
-
-enum HDLightUnit {
-    HD_LIGHT_UNIT_LUMEN = 0;
-    HD_LIGHT_UNIT_CANDELA = 1;
-    HD_LIGHT_UNIT_LUX = 2;
-    HD_LIGHT_UNIT_NITS = 3;
-    HD_LIGHT_UNIT_EV100 = 4;
+    optional bool interacts_with_sky = 2;      // drives Physically Based Sky
+    optional bool affect_diffuse = 3;
+    optional bool affect_specular = 4;
+    optional bool affects_volumetric = 5;
+    optional float light_dimmer = 6;
+    optional float volumetric_dimmer = 7;
+    optional float shadow_dimmer = 8;
+    optional float volumetric_shadow_dimmer = 9;
+    optional float volumetric_fade_distance = 10;
+    optional float shape_radius = 11;
+    optional bool apply_range_attenuation = 12;
+    optional common.Color surface_tint = 13;
+    optional common.Color shadow_tint = 14;
 }

--- a/proto/plume/sample/unity/light.proto
+++ b/proto/plume/sample/unity/light.proto
@@ -58,10 +58,22 @@ message LightUpdate {
     optional float cookie_size = 30;
 
     optional AssetIdentifier flare = 31;
+
+    // Physical light unit (Unity 6 core Light API). HDRP/URP interpret `intensity`
+    // relative to this unit; absent on records from older versions.
+    optional LightUnit light_unit = 32;
 }
 
 message LayerShadowCullDistances {
     repeated float distances = 1;
+}
+
+enum LightUnit {
+    LIGHT_UNIT_LUMEN = 0;
+    LIGHT_UNIT_CANDELA = 1;
+    LIGHT_UNIT_LUX = 2;
+    LIGHT_UNIT_NITS = 3;
+    LIGHT_UNIT_EV100 = 4;
 }
 
 enum LightType {

--- a/proto/plume/sample/unity/settings/hdrp_global_settings.proto
+++ b/proto/plume/sample/unity/settings/hdrp_global_settings.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package plume.sample.unity.settings;
+option csharp_namespace = "PLUME.Sample.Unity.Settings";
+
+import "plume/sample/unity/identifiers.proto";
+
+// Corresponds to the HDRP default volume profile (base of every volume stack:
+// VisualEnvironment / sky / fog / default exposure). Referenced by asset id so
+// the existing VolumeProfile asset-bundling carries it.
+message HDRPGlobalSettingsUpdate {
+    optional AssetIdentifier default_volume_profile = 1;
+}


### PR DESCRIPTION
New plume.sample.unity.hdrp package: HDAdditionalLightData and HDAdditionalCameraData messages. New settings/hdrp_global_settings.proto (HDRPGlobalSettingsUpdate, default volume profile). Adds optional light_unit to the core light message (Unity 6 physical light units). All additive; existing messages unchanged.